### PR TITLE
Fix stat_post_url functionality (Fixes #43)

### DIFF
--- a/slscore/HttpClient.cpp
+++ b/slscore/HttpClient.cpp
@@ -33,7 +33,7 @@
 #define HTTP_REQUEST_HEADER_ACCEPT         "Accept: text/html, */*\r\n"
 //   Accept: text/html, */*
 #define HTTP_REQUEST_HEADER_USER_AGENT     "User-Agent: srt-live-server\r\n"
-#define HTTP_REQUEST_HEADER_CONTENT_TYPE   "Content-Type: application/x-www-form-urlencoded\r\n"
+#define HTTP_REQUEST_HEADER_CONTENT_TYPE   "Content-Type: application/json\r\n"
 //   Host: localhost:8080
 //   Content-Length: 15
 #define HTTP_REQUEST_HEADER_CONNECTION     "Connection: Keep-Alive\r\n"
@@ -90,7 +90,7 @@ int  CHttpClient::open(const char *url, const char *method, int interval)
 		goto FUNC_END;
 	}
 	if (NULL != method && strlen(method) > 0) {
-		sprintf(m_http_method, method);
+		strcpy(m_http_method, method);
 	}
 
 	m_interval = interval;
@@ -279,7 +279,7 @@ int CHttpClient::parse_http_response(std::string &response)
 
     	//Content-Length
 		std::string dst = std::string("Content-Length:");
-		std::string content_length = sls_find_string(m_response_info.m_response_header, dst);
+		std::string content_length = sls_find_string(m_response_info.m_response_header, dst, false);
 		if (content_length.length() > 0) {
 	    	sls_split_string(content_length, ":", parts, 1);
 		    if (parts.size() == 2) {

--- a/slscore/SLSGroup.cpp
+++ b/slscore/SLSGroup.cpp
@@ -297,6 +297,8 @@ void CSLSGroup::check_invalid_sock()
         if (update_stat_info) {
             std::string stat_info = role->get_stat_info();
             CSLSLock lock(&m_mutex_stat);
+            // add delimiter between JSON objects
+            if (it != m_map_role.end() && !stat_info.empty()) stat_info += ',';
             m_stat_info.append(stat_info);
         }
 

--- a/slscore/SLSManager.cpp
+++ b/slscore/SLSManager.cpp
@@ -284,17 +284,24 @@ int  CSLSManager::check_invalid()
     return SLS_ERROR;
 }
 
-void CSLSManager::get_stat_info(std::string &info)
+void CSLSManager::get_stat_info(std::string &info_str)
 {
+    info_str += '[';
+
     std::list<CSLSGroup *>::iterator it;
     std::list<CSLSGroup *>::iterator it_end = m_workers.end();
-    for ( it = m_workers.begin(); it != it_end; ) {
+    for ( it = m_workers.begin(); it != it_end; it++ ) {
     	CSLSGroup *worker = *it;
-    	it++;
     	if (NULL != worker) {
-    		worker->get_stat_info(info);
+            std::string worker_info;
+    		worker->get_stat_info(worker_info);
+            // add delimiter between JSON objects
+            if (it != m_workers.begin() && !worker_info.empty()) info_str += ',';
+            info_str += worker_info;
     	}
     }
+
+    info_str += ']';
 }
 
 int  CSLSManager::stat_client_callback(void *p, HTTP_CALLBACK_TYPE type, void *v, void* context)

--- a/slscore/common.cpp
+++ b/slscore/common.cpp
@@ -41,6 +41,7 @@
 #include <string.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <string>
 #include <vector>
 
@@ -440,12 +441,15 @@ void sls_split_string(std::string str, std::string separator, std::vector<std::s
 	ADD_VECTOR_END(result, str.substr(lastPosition, string::npos));
 }
 
-std::string sls_find_string(std::vector<std::string> &src, std::string &dst)
+std::string sls_find_string(std::vector<std::string> &src, std::string &dst, bool caseSensitive)
 {
+    if (!caseSensitive) std::transform(dst.begin(), dst.end(), dst.begin(), ::tolower);
+
 	std::string ret = std::string("");
 	std::vector<std::string>::iterator it;
     for(it=src.begin(); it!=src.end();) {
     	std::string str = *it;
+        if (!caseSensitive) std::transform(str.begin(), str.end(), str.begin(), ::tolower);
     	it ++;
     	string::size_type pos = str.find(dst);
     	if (pos != std::string::npos)

--- a/slscore/common.hpp
+++ b/slscore/common.hpp
@@ -103,7 +103,7 @@ int sls_remove_pid();
 int sls_send_cmd(const char *cmd);
 
 void sls_split_string(std::string str, std::string separator, std::vector<std::string> &result, int count=-1);
-std::string sls_find_string(std::vector<std::string> &src, std::string &dst);
+std::string sls_find_string(std::vector<std::string> &src, std::string &dst, bool caseSensitive);
 
 
 /*

--- a/srt-live-server.cpp
+++ b/srt-live-server.cpp
@@ -153,8 +153,9 @@ int main(int argc, char* argv[])
         sls_log(SLS_LOG_INFO, "sls_manager->start failed, EXIT!");
         goto EXIT_PROC;
     }
-
     conf_srt = (sls_conf_srt_t *)sls_conf_get_root_conf();
+
+    http_stat_client->set_stage_callback(CSLSManager::stat_client_callback, sls_manager);
     if (strlen(conf_srt->stat_post_url) > 0)
         http_stat_client->open(conf_srt->stat_post_url, stat_method, conf_srt->stat_post_interval);
 
@@ -237,8 +238,11 @@ int main(int argc, char* argv[])
                 sls_log(SLS_LOG_INFO, "reload, failed, sls_manager->start, exit.");
                 break;
             }
+
+            http_stat_client->set_stage_callback(CSLSManager::stat_client_callback, sls_manager);
             if (strlen(conf_srt->stat_post_url) > 0)
                 http_stat_client->open(conf_srt->stat_post_url, stat_method, conf_srt->stat_post_interval);
+
             sls_log(SLS_LOG_INFO, "reload successfully.");
 		}
 	}


### PR DESCRIPTION
I fixed a few things here to generally bring the stat post functionality up to snuff.

- Change Content-Type header for stat POST to `application/json`
  - Not sure why this was urlencoded before, nothing in the code seems to send urlencoded bodies - on_event uses query params
- Fix sprintf usage in HttpClient
  - m_http_method was being nulled out on subsequent requests.
- Fix Content-Length header string find operation
  - HTTP headers are case insensitive, so some servers would send back lower case `content-length` and the request would fail.
- Set callback for http_stat_client
  - It seems this was the crux of the issue here, the request body callback in SLSManager was never actually hooked up.
- Send properly formatted JSON
  - Before, all the stat objects were simply appended into one big string. I fixed this so it POSTs a properly formatted JSON array.

As a side note, the indentation and formatting of the repo seemed to be all over the place... so I hope I got that right. Also I don't use C++ much, so hopefully some more experienced eyes can take a look here.

Fixes #43.