### PR TITLE
Added comments from the Directives Wiki into the default configuration file, and fixed a segfault when starting SLS with no config file

### DIFF
--- a/sls.conf
+++ b/sls.conf
@@ -1,40 +1,90 @@
-srt {                #SRT
+# SLS configuration
+# Help copied from https://github.com/Edward-Wu/srt-live-server/wiki/Directives
+
+srt {                
+    # worker threads for sls, it is recommended than threads match the count of cpu core.
     worker_threads  1;
+
+    # the max client connection for each worker thread, please set this value according the cpu ability
     worker_connections 300 ;
 		
     log_file logs/error.log ; 
     log_level info;
     
-    #stat_post_url http://192.168.31.106:8001/sls/stat;
-    #stat_post_interval  5;#s
-    
-    record_hls_path_prefix /tmp/mov/sls; 
-    #vod  file name: /tmp/mov/sls/$listen/$domain_publisher/$app_publisher/$stream_name/vod.m3u8
-         
-    server {
-        listen 8080; 
-        latency 20; #ms
+    # statistic info url, sls will post the statistic info with it.
+    # stat_post_url http://192.168.31.106:8001/sls/stat;
+    # stat_post_interval  5;#s
 
+    # the prefix of record hls   
+    # vod file name will be: /tmp/mov/sls/$listen/$domain_publisher/$app_publisher/$stream_name/vod.m3u8
+    record_hls_path_prefix /tmp/mov/sls;
+        
+    server {
+
+	# the sls listen port.
+        listen 8080; 
+
+        # the net latency of srt. unit:ms
+	latency 20; #ms
+
+        # the play url domain name which can be more than one, divided by space , example: live.sls.com live-1.sls.com;
         domain_player live.sls.com live-1.sls.com;
-        domain_publisher uplive.sls.com;
-        backlog 100; #accept connections at the same time
-        idle_streams_timeout 10;#s -1: unlimited
-        #on_event_url http://192.168.31.106:8000/sls/on_event; #?method=on_connect|on_close&role_name=&srt_url=%s
-        app {
-            app_player live ;           
-            app_publisher live ; 
+
+        # the publish url domain name witch mast be single. example: uplive.sls.com;
+	domain_publisher uplive.sls.com;
+	
+        # accept connections at the same time
+	backlog 100;
+
+	# the timeout of no data, when timeout the server will discard the client. 
+	# unit s, -1 is unlimited, for player and publisher.
+	idle_streams_timeout 10;
+	
+        # the sls post the on_connect and on_close event to the http manager server, the syntax of the post url is like:
+        # http://192.168.31.106:8000/sls/on_event?method=on_connect|on_close&role_name=%s&srt_url=%s&remote_ip=%s&remote_ip=%d
+        # in the http manager server, we can check the connection through the role name, srt_url, remote ip and remote port,
+        # if return not http reponse code 200 OK, the connection will be refused. we also can record the begin time
+        # and end time for the connection.
+        
+	# on_event_url http://192.168.31.106:8000/sls/on_event; #?method=on_connect|on_close&role_name=&srt_url=%s
+        
+	app {
+
+            # player app name, the srt url is like rtmp's, such as :srt://domain/live/stream_name ;
+	    app_player live;           
+
+            # the publisher app name;
+	    app_publisher live; 
             
-            record_hls off;#on, off 
-            record_hls_segment_duration 10; #unit s
+            # the record hls switch, on, off, default is off.
+            record_hls off;
+
+            # the dutaion of ts segment, unit s, default is 10s.
+	    record_hls_segment_duration 10;
             
             #relay {
-            #    type pull;
-            #    mode loop;#loop; hash;
-            #    reconnect_interval 10;
-            #    idle_streams_timeout -1;#s -1: unlimited
-            #    upstreams 127.0.0.1:9090?streamid=live.sls.com/live 192.168.1.100:8080/?streamid=live.test.com/live;
+
+		# - the type of relay, support two type: pull, push;
+                # type pull;
+
+                # - the relay mode, support two mode: loop, hash;
+                # - in the loop mode, sls will loop to connect upstreams url one by one until connection is successfully.
+                # - in the hash mode, sls will connect the upstreams server with the url hash.
+                # mode loop;
+
+                # - reconnect interval when connection is failed, unit s;
+                # reconnect_interval 10;
+
+                # - the timeout of no data, when timeout the server will discard the relay. unit s, -1 is unlimited.
+                # idle_streams_timeout -1;
+
+                # - the relay upstream url, if there are more than one, divide with space, such as:
+                # - 127.0.0.1:9090?streamid=live.sls.com/live 192.168.1.100:8080/?streamid=live.test.com/live;
+                # upstreams 127.0.0.1:9090?streamid=live.sls.com/live 192.168.1.100:8080/?streamid=live.test.com/live;
+
             #}
-            #relay {
+
+	    #relay {
             #    type push;
             #    mode all; #all; hash
             #    reconnect_interval 10;

--- a/sls.conf
+++ b/sls.conf
@@ -1,70 +1,71 @@
 # SLS configuration
 # Help copied from https://github.com/Edward-Wu/srt-live-server/wiki/Directives
 
-srt {                
+srt {
+
     # worker threads for sls, it is recommended than threads match the count of cpu core.
     worker_threads  1;
 
     # the max client connection for each worker thread, please set this value according the cpu ability
     worker_connections 300 ;
-		
-    log_file logs/error.log ; 
+
+    log_file logs/error.log ;
     log_level info;
-    
+
     # statistic info url, sls will post the statistic info with it.
     # stat_post_url http://192.168.31.106:8001/sls/stat;
     # stat_post_interval  5;#s
 
-    # the prefix of record hls   
+    # the prefix of record hls
     # vod file name will be: /tmp/mov/sls/$listen/$domain_publisher/$app_publisher/$stream_name/vod.m3u8
     record_hls_path_prefix /tmp/mov/sls;
-        
+
     server {
 
-	# the sls listen port.
-        listen 8080; 
+        # the sls listen port.
+        listen 8080;
 
         # the net latency of srt. unit:ms
-	latency 20; #ms
+        latency 20; #ms
 
         # the play url domain name which can be more than one, divided by space , example: live.sls.com live-1.sls.com;
         domain_player live.sls.com live-1.sls.com;
 
         # the publish url domain name witch mast be single. example: uplive.sls.com;
-	domain_publisher uplive.sls.com;
-	
-        # accept connections at the same time
-	backlog 100;
+        domain_publisher uplive.sls.com;
 
-	# the timeout of no data, when timeout the server will discard the client. 
-	# unit s, -1 is unlimited, for player and publisher.
-	idle_streams_timeout 10;
-	
+        # accept connections at the same time
+        backlog 100;
+
+        # the timeout of no data, when timeout the server will discard the client.
+        # unit s, -1 is unlimited, for player and publisher.
+        idle_streams_timeout 10;
+
         # the sls post the on_connect and on_close event to the http manager server, the syntax of the post url is like:
         # http://192.168.31.106:8000/sls/on_event?method=on_connect|on_close&role_name=%s&srt_url=%s&remote_ip=%s&remote_ip=%d
         # in the http manager server, we can check the connection through the role name, srt_url, remote ip and remote port,
         # if return not http reponse code 200 OK, the connection will be refused. we also can record the begin time
         # and end time for the connection.
-        
-	# on_event_url http://192.168.31.106:8000/sls/on_event; #?method=on_connect|on_close&role_name=&srt_url=%s
-        
-	app {
+
+        # on_event_url http://192.168.31.106:8000/sls/on_event; #?method=on_connect|on_close&role_name=&srt_url=%s
+
+        app {
 
             # player app name, the srt url is like rtmp's, such as :srt://domain/live/stream_name ;
-	    app_player live;           
+            app_player live;
 
             # the publisher app name;
-	    app_publisher live; 
-            
+            app_publisher live;
+
             # the record hls switch, on, off, default is off.
             record_hls off;
 
             # the dutaion of ts segment, unit s, default is 10s.
-	    record_hls_segment_duration 10;
-            
+            record_hls_segment_duration 10;
+
             #relay {
 
-		# - the type of relay, support two type: pull, push;
+                # - the type of relay, support two type: pull, push;
                 # type pull;
 
                 # - the relay mode, support two mode: loop, hash;
@@ -84,13 +85,13 @@ srt {
 
             #}
 
-	    #relay {
+            #relay {
             #    type push;
             #    mode all; #all; hash
             #    reconnect_interval 10;
             #    idle_streams_timeout 10;#s -1: unlimited
             #    upstreams 192.168.31.106:8080?streamid=uplive.sls.com/live ;
-            #}          
+            #}
         }
     }
 }

--- a/slscore/HttpClient.cpp
+++ b/slscore/HttpClient.cpp
@@ -33,7 +33,7 @@
 #define HTTP_REQUEST_HEADER_ACCEPT         "Accept: text/html, */*\r\n"
 //   Accept: text/html, */*
 #define HTTP_REQUEST_HEADER_USER_AGENT     "User-Agent: srt-live-server\r\n"
-#define HTTP_REQUEST_HEADER_CONTENT_TYPE   "Content-Type: application/x-www-form-urlencoded\r\n"
+#define HTTP_REQUEST_HEADER_CONTENT_TYPE   "Content-Type: application/json\r\n"
 //   Host: localhost:8080
 //   Content-Length: 15
 #define HTTP_REQUEST_HEADER_CONNECTION     "Connection: Keep-Alive\r\n"
@@ -90,7 +90,7 @@ int  CHttpClient::open(const char *url, const char *method, int interval)
 		goto FUNC_END;
 	}
 	if (NULL != method && strlen(method) > 0) {
-		sprintf(m_http_method, method);
+		strcpy(m_http_method, method);
 	}
 
 	m_interval = interval;
@@ -279,7 +279,7 @@ int CHttpClient::parse_http_response(std::string &response)
 
     	//Content-Length
 		std::string dst = std::string("Content-Length:");
-		std::string content_length = sls_find_string(m_response_info.m_response_header, dst);
+		std::string content_length = sls_find_string(m_response_info.m_response_header, dst, false);
 		if (content_length.length() > 0) {
 	    	sls_split_string(content_length, ":", parts, 1);
 		    if (parts.size() == 2) {

--- a/slscore/SLSGroup.cpp
+++ b/slscore/SLSGroup.cpp
@@ -297,6 +297,8 @@ void CSLSGroup::check_invalid_sock()
         if (update_stat_info) {
             std::string stat_info = role->get_stat_info();
             CSLSLock lock(&m_mutex_stat);
+            // add delimiter between JSON objects
+            if (it != m_map_role.end() && !stat_info.empty()) stat_info += ',';
             m_stat_info.append(stat_info);
         }
 

--- a/slscore/SLSManager.cpp
+++ b/slscore/SLSManager.cpp
@@ -284,17 +284,24 @@ int  CSLSManager::check_invalid()
     return SLS_ERROR;
 }
 
-void CSLSManager::get_stat_info(std::string &info)
+void CSLSManager::get_stat_info(std::string &info_str)
 {
+    info_str += '[';
+
     std::list<CSLSGroup *>::iterator it;
     std::list<CSLSGroup *>::iterator it_end = m_workers.end();
-    for ( it = m_workers.begin(); it != it_end; ) {
+    for ( it = m_workers.begin(); it != it_end; it++ ) {
     	CSLSGroup *worker = *it;
-    	it++;
     	if (NULL != worker) {
-    		worker->get_stat_info(info);
+            std::string worker_info;
+    		worker->get_stat_info(worker_info);
+            // add delimiter between JSON objects
+            if (it != m_workers.begin() && !worker_info.empty()) info_str += ',';
+            info_str += worker_info;
     	}
     }
+
+    info_str += ']';
 }
 
 int  CSLSManager::stat_client_callback(void *p, HTTP_CALLBACK_TYPE type, void *v, void* context)

--- a/slscore/common.cpp
+++ b/slscore/common.cpp
@@ -41,6 +41,7 @@
 #include <string.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <string>
 #include <vector>
 
@@ -440,12 +441,15 @@ void sls_split_string(std::string str, std::string separator, std::vector<std::s
 	ADD_VECTOR_END(result, str.substr(lastPosition, string::npos));
 }
 
-std::string sls_find_string(std::vector<std::string> &src, std::string &dst)
+std::string sls_find_string(std::vector<std::string> &src, std::string &dst, bool caseSensitive)
 {
+    if (!caseSensitive) std::transform(dst.begin(), dst.end(), dst.begin(), ::tolower);
+
 	std::string ret = std::string("");
 	std::vector<std::string>::iterator it;
     for(it=src.begin(); it!=src.end();) {
     	std::string str = *it;
+        if (!caseSensitive) std::transform(str.begin(), str.end(), str.begin(), ::tolower);
     	it ++;
     	string::size_type pos = str.find(dst);
     	if (pos != std::string::npos)

--- a/slscore/common.hpp
+++ b/slscore/common.hpp
@@ -103,7 +103,7 @@ int sls_remove_pid();
 int sls_send_cmd(const char *cmd);
 
 void sls_split_string(std::string str, std::string separator, std::vector<std::string> &result, int count=-1);
-std::string sls_find_string(std::vector<std::string> &src, std::string &dst);
+std::string sls_find_string(std::vector<std::string> &src, std::string &dst, bool caseSensitive);
 
 
 /*

--- a/slscore/conf.cpp
+++ b/slscore/conf.cpp
@@ -377,7 +377,9 @@ void sls_conf_release(sls_conf_base_t * c)
 void sls_conf_close()
 {
     sls_conf_base_t * c = sls_first_conf.child;
-    sls_conf_release(c);
+    if (c != NULL) {
+        sls_conf_release(c);
+    }
 }
 
 sls_conf_base_t * sls_conf_get_root_conf()

--- a/srt-live-server.cpp
+++ b/srt-live-server.cpp
@@ -153,8 +153,9 @@ int main(int argc, char* argv[])
         sls_log(SLS_LOG_INFO, "sls_manager->start failed, EXIT!");
         goto EXIT_PROC;
     }
-
     conf_srt = (sls_conf_srt_t *)sls_conf_get_root_conf();
+
+    http_stat_client->set_stage_callback(CSLSManager::stat_client_callback, sls_manager);
     if (strlen(conf_srt->stat_post_url) > 0)
         http_stat_client->open(conf_srt->stat_post_url, stat_method, conf_srt->stat_post_interval);
 
@@ -237,8 +238,11 @@ int main(int argc, char* argv[])
                 sls_log(SLS_LOG_INFO, "reload, failed, sls_manager->start, exit.");
                 break;
             }
+
+            http_stat_client->set_stage_callback(CSLSManager::stat_client_callback, sls_manager);
             if (strlen(conf_srt->stat_post_url) > 0)
                 http_stat_client->open(conf_srt->stat_post_url, stat_method, conf_srt->stat_post_interval);
+
             sls_log(SLS_LOG_INFO, "reload successfully.");
 		}
 	}


### PR DESCRIPTION
meant to be 2 separate PRs for your consideration, but forgot to create a branch :(

- Added the comments from the directives Wiki to the sls.conf
- When SLS was started without a "-c", there was a segfault at the end:

```
-------------------------------------------------
           srt-live-srver 
                    v1.4.x 
-------------------------------------------------
    
2020-09-19 13:58:56:239 SLS INFO: sls_conf_open, parsing conf file='./sls.conf'.
2020-09-19 13:58:56:239 SLS FATAL: open conf file='./sls.conf' failed, please check if the file exist.
2020-09-19 13:58:56:239 SLS INFO: sls_conf_open failed, EXIT!
2020-09-19 13:58:56:239 SLS INFO: exit, stop srt live server...
2020-09-19 13:58:56:239 SLS INFO: exit, release reload_manager_list begin，count=0.
2020-09-19 13:58:56:239 SLS INFO: exit, release reload_manager_list ok.
2020-09-19 13:58:56:239 SLS INFO: exit, release http_stat_client.
2020-09-19 13:58:56:239 SLS INFO: exit, uninit srt .
2020-09-19 13:58:56:239 SLS INFO: exit, close conf.
Segmentation fault

```
Just checking c != null on closing the config fixes the issue. 
