### PR TITLE
get_passphrase_url endpoint

### DIFF
--- a/sls.conf
+++ b/sls.conf
@@ -12,18 +12,18 @@ srt {                #SRT
     #vod  file name: /tmp/mov/sls/$listen/$domain_publisher/$app_publisher/$stream_name/vod.m3u8
 
     server {
-        listen 1234;
+        listen 8080;
         latency 20; #ms
 
         domain_player live.sls.com live-1.sls.com;
         domain_publisher uplive.sls.com;
         backlog 100; #accept connections at the same time
         idle_streams_timeout 10;#s -1: unlimited
-        on_event_url http://762c7d017a57.ngrok.io/ok; #?method=on_connect|on_close&role_name=&srt_url=%s
+        #on_event_url http://192.168.31.106:8000/sls/on_event; #?method=on_connect|on_close&role_name=&srt_url=%s
 
         # sends a post request with streamid before accepting socket connection
         # should return plain text passphrase to be used or empty string if no passphrase
-        get_passphrase_url http://127.0.0.1:6001/srt/passphrase; #?streamid=domain/app/name
+        #get_passphrase_url http://127.0.0.1:6001/srt/passphrase; #?streamid=domain/app/name
         app {
             app_player live ;
             app_publisher live ;

--- a/sls.conf
+++ b/sls.conf
@@ -1,32 +1,36 @@
 srt {                #SRT
     worker_threads  1;
     worker_connections 300 ;
-		
-    log_file logs/error.log ; 
+
+    log_file logs/error.log ;
     log_level info;
-    
+
     #stat_post_url http://192.168.31.106:8001/sls/stat;
     #stat_post_interval  5;#s
-    
-    record_hls_path_prefix /tmp/mov/sls; 
+
+    record_hls_path_prefix /tmp/mov/sls;
     #vod  file name: /tmp/mov/sls/$listen/$domain_publisher/$app_publisher/$stream_name/vod.m3u8
-         
+
     server {
-        listen 8080; 
+        listen 1234;
         latency 20; #ms
 
         domain_player live.sls.com live-1.sls.com;
         domain_publisher uplive.sls.com;
         backlog 100; #accept connections at the same time
         idle_streams_timeout 10;#s -1: unlimited
-        #on_event_url http://192.168.31.106:8000/sls/on_event; #?method=on_connect|on_close&role_name=&srt_url=%s
+        on_event_url http://762c7d017a57.ngrok.io/ok; #?method=on_connect|on_close&role_name=&srt_url=%s
+
+        # sends a post request with streamid before accepting socket connection
+        # should return plain text passphrase to be used or empty string if no passphrase
+        get_passphrase_url http://127.0.0.1:6001/srt/passphrase; #?streamid=domain/app/name
         app {
-            app_player live ;           
-            app_publisher live ; 
-            
-            record_hls off;#on, off 
+            app_player live ;
+            app_publisher live ;
+
+            record_hls off;#on, off
             record_hls_segment_duration 10; #unit s
-            
+
             #relay {
             #    type pull;
             #    mode loop;#loop; hash;
@@ -40,7 +44,7 @@ srt {                #SRT
             #    reconnect_interval 10;
             #    idle_streams_timeout 10;#s -1: unlimited
             #    upstreams 192.168.31.106:8080?streamid=uplive.sls.com/live ;
-            #}          
+            #}
         }
     }
 }

--- a/slscore/HttpClient.cpp
+++ b/slscore/HttpClient.cpp
@@ -322,6 +322,7 @@ int CHttpClient::recv()
         }
         data[n] = 0;
         http_response += std::string(data);
+				usleep(10);
 	}
 	if (http_response.length() > 0) {
 		//parse the response

--- a/slscore/SLSListener.cpp
+++ b/slscore/SLSListener.cpp
@@ -297,6 +297,10 @@ int CSLSListener::start()
     }
     sls_log(SLS_LOG_INFO, "[%p]CSLSListener::start, libsrt_setup ok.", this);
 
+    char * tmp_get_passphrase_url = ((sls_conf_server_t*)m_conf)->get_passphrase_url;
+    if (NULL != tmp_get_passphrase_url && strlen(tmp_get_passphrase_url) > 0) {
+        m_srt->setup_passphrase_endpoint(tmp_get_passphrase_url);
+    }
 
     ret = m_srt->libsrt_listen(m_back_log);
     if (SLS_OK != ret) {

--- a/slscore/SLSListener.hpp
+++ b/slscore/SLSListener.hpp
@@ -48,6 +48,7 @@ int              backlog;
 int              latency;
 int              idle_streams_timeout;//unit s; -1: unlimited
 char             on_event_url[URL_MAX_LEN];
+char             get_passphrase_url[URL_MAX_LEN];
 SLS_CONF_DYNAMIC_DECLARE_END
 
 /**
@@ -61,6 +62,7 @@ SLS_SET_CONF(server, int,    backlog,              "how many sockets may be allo
 SLS_SET_CONF(server, int,    latency,              "latency.", 1, 300),
 SLS_SET_CONF(server, int,    idle_streams_timeout, "players idle timeout when no publisher" , -1, 86400),
 SLS_SET_CONF(server, string, on_event_url,         "on connect/close http url", 1,    URL_MAX_LEN-1),
+SLS_SET_CONF(server, string, get_passphrase_url,   "get passphrase http url", 1,    URL_MAX_LEN-1),
 SLS_CONF_CMD_DYNAMIC_DECLARE_END
 
 

--- a/slscore/SLSRelay.cpp
+++ b/slscore/SLSRelay.cpp
@@ -188,7 +188,6 @@ int CSLSRelay::parse_url(char* url, char *host_name, int& port, char * streamid)
 }
 
 int CSLSRelay::open(const char * srt_url) {
-
     int yes = 1;
     int no = 0;
     char host_name[128] = "192.168.31.56";//test

--- a/slscore/SLSSrt.cpp
+++ b/slscore/SLSSrt.cpp
@@ -249,7 +249,6 @@ int handle_srt_listen_callback(void* opaque, SRTSOCKET ns, int hs_version, const
             if (SLS_OK == m_http_client->check_finished() || SLS_OK == m_http_client->check_timeout()) {
                 break;
             }
-            usleep(10);
         }
 
         HTTP_RESPONSE_INFO * re = m_http_client->get_response_info();

--- a/slscore/SLSSrt.hpp
+++ b/slscore/SLSSrt.hpp
@@ -26,6 +26,7 @@
 #ifndef _SLSRrt_INCLUDE_
 #define _SLSRrt_INCLUDE_
 
+#include "HttpClient.hpp"
 #include <srt/srt.h>
 
 enum SRTMode {
@@ -120,6 +121,8 @@ public :
 
     void libsrt_set_latency(int latency);
 
+    void setup_passphrase_endpoint(const char * http_url_passphrase);
+    char *get_passphrase_endpoint();
 
     static int  libsrt_neterrno();
     static void libsrt_print_error_info();
@@ -128,7 +131,8 @@ public :
 protected:
     SRTContext m_sc;
     char m_peer_name[256];//peer ip addr, such as 172.12.22.14
-    int  m_peer_port ;
+    int  m_peer_port;
+    char m_http_url_passphrase[URL_MAX_LEN];
 
 private:
     static bool m_inited;

--- a/slscore/TCPRole.cpp
+++ b/slscore/TCPRole.cpp
@@ -58,9 +58,9 @@ int CTCPRole::handler(DATA_PARAM *p)
 int CTCPRole::write(const char * buf, int size)
 {
 	int len = 0;
-	len = send(m_fd, buf, size, 0);
+	len = send(m_fd, buf, size, MSG_NOSIGNAL);
 	if (0 >= len) {
-        sls_log(SLS_LOG_INFO, "[%p]CTCPRole::read, len=%d, errno=%d, err='%s'",
+        sls_log(SLS_LOG_INFO, "[%p]CTCPRole::write, len=%d, errno=%d, err='%s'",
         		this, len, errno, strerror(errno));
 
 	}


### PR DESCRIPTION
Trying to address the ability to handle different passphrases.
What it does:
When defined, a request will be made to get_passphrase_url endpoint with streamid as passed, and if that endpoint returns a non-empty string it will be used as passphrase for that socket connection. An empty string should be returned in order to use no passphrase.

NOTES:
* I'm not at all good with c++, so everything might be simply wrong
* I'm not sure code is organized and clean
* If the HTTP endpoint does not exist, code dies. Could not figure out why

Any comment is appreciated.