### PR TITLE
Makefile install phase and fix insecure printfs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+PREFIX = /usr/local
 SHELL = /bin/sh
 MAIN_NAME=sls
 CLIENT_NAME=slc
@@ -63,4 +64,17 @@ $(OUTPUT_PATH)/%.o: ./$(CORE_PATH)/%.cpp
 clean:
 	rm -f $(OUTPUT_PATH)/*.o
 	rm -rf $(BIN_PATH)/*
+
+install: all
+	@echo installing executable files to ${DESTDIR}${PREFIX}/bin
+	@mkdir -p "${DESTDIR}${PREFIX}/bin"
+	@cp -f ${BIN_PATH}/${MAIN_NAME} "${DESTDIR}${PREFIX}/bin"
+	@chmod 755 "${DESTDIR}${PREFIX}/bin/${MAIN_NAME}"
+	@cp -f ${BIN_PATH}/${CLIENT_NAME} "${DESTDIR}${PREFIX}/bin"
+	@chmod 755 "${DESTDIR}${PREFIX}/bin/${CLIENT_NAME}"
+
+uninstall:
+	@echo removing executable files from ${DESTDIR}${PREFIX}/bin
+	@rm -f "${DESTDIR}${PREFIX}/bin/${MAIN_NAME}"
+	@rm -f "${DESTDIR}${PREFIX}/bin/${CLIENT_NAME}"
 

--- a/slscore/HttpClient.cpp
+++ b/slscore/HttpClient.cpp
@@ -90,7 +90,7 @@ int  CHttpClient::open(const char *url, const char *method, int interval)
 		goto FUNC_END;
 	}
 	if (NULL != method && strlen(method) > 0) {
-		sprintf(m_http_method, method);
+		strcpy(m_http_method, method);
 	}
 
 	m_interval = interval;

--- a/slscore/SLSSrt.cpp
+++ b/slscore/SLSSrt.cpp
@@ -124,7 +124,7 @@ SRTS_NONEXIST:
     std::map<int, std::string>::iterator it;
     for(it=map_error.begin(); it!=map_error.end(); ++it) {
         sprintf(szBuf, "%d: %s\n", it->first, it->second.c_str());
-        printf(szBuf);
+        puts(szBuf);
     }
     printf("----------end------------\n");
     map_error.clear();


### PR DESCRIPTION
Added an install phase to ease the packaging process on NixOS.
I also fixed some unsecure printfs, cf [https://fedoraproject.org/wiki/Format-Security-FAQ](https://fedoraproject.org/wiki/Format-Security-FAQ).