### PR TITLE
Add ctime for compilation in musl

### DIFF
--- a/slscore/common.hpp
+++ b/slscore/common.hpp
@@ -29,6 +29,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <string>
+#include <ctime>
 #include <vector>
 #include <unistd.h>
 


### PR DESCRIPTION
All of the time functions used in this file aren't provided by musl libc, but adding **ctime** as an include provides the ability to compile this project under musl.