### PR TITLE
Add missing header include

### DIFF
--- a/slscore/common.cpp
+++ b/slscore/common.cpp
@@ -39,6 +39,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <unistd.h>
 
 #include <string>


### PR DESCRIPTION
This patch includes `time.h` in commonslscore/common.cpp as this is required in order to use the `time` function.